### PR TITLE
fix: fix wrong link in category

### DIFF
--- a/templates/_partials/post/post-meta.html
+++ b/templates/_partials/post/post-meta.html
@@ -35,7 +35,7 @@
             <span class="post-meta-item-text">I</span>
             <th:block th:each="category:${post.categories}">
                 <span itemprop="about" itemscope="" itemtype="http://schema.org/Thing">
-                  <a href="/categories/Sports/" itemprop="url" rel="index"><span itemprop="name" th:text="${category.spec.displayName}">Sports</span></a>
+                  <a th:href="${category.status.permalink}" itemprop="url" rel="index"><span itemprop="name" th:text="${category.spec.displayName}">Sports</span></a>
                 </span>
             </th:block>
         </span>


### PR DESCRIPTION
原先在文件列表点击分类标签跳转到的是写死的`/categories/Sports/`，导致跳转地址错误，该commit修复了模板中的错误